### PR TITLE
Adding VehicleOdometry.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MSG_FILES
   "SignalArray.msg"
   "VehicleControlData.msg"
   "VehicleStateData.msg"
+  "VehicleOdometry.msg"
 )
 
 if(${ROS_VERSION} EQUAL 1)

--- a/msg/VehicleOdometry.msg
+++ b/msg/VehicleOdometry.msg
@@ -1,0 +1,5 @@
+std_msgs/Header header
+
+float32 velocity # meters / second 
+float32 front_wheel_angle # radians
+float32 rear_wheel_angle # radians


### PR DESCRIPTION
Vehicle odometry message for tracking vehicle velocity and wheel angles. Used for `VehicleOdometryData` type with LGSVL `VehicleOdometrySensor` sensor.